### PR TITLE
File system operations #49

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5185,7 +5185,7 @@ dependencies = [
 [[package]]
 name = "save-dweb-backend"
 version = "0.1.0"
-source = "git+https://github.com/OpenArchive/save-dweb-backend#f4b59ea9abd3cdb24c3263f489159e4dc2156525"
+source = "git+https://github.com/OpenArchive/save-dweb-backend#7ea85a6a0c9b459d2bffad2102266a90369dbb65"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -6611,7 +6611,7 @@ dependencies = [
 [[package]]
 name = "veilid-core"
 version = "0.3.4"
-source = "git+https://gitlab.com/veilid/veilid.git?branch=main#9bb4863b299e0998963bf860c47adbe445968a8a"
+source = "git+https://gitlab.com/veilid/veilid.git?branch=main#14cd561e09276fd17077c7c7e2b8ca287d42484b"
 dependencies = [
  "argon2",
  "async-io",
@@ -6730,7 +6730,7 @@ dependencies = [
 [[package]]
 name = "veilid-iroh-blobs"
 version = "0.1.0"
-source = "git+https://github.com/RangerMauve/veilid-iroh-blobs.git?branch=default#b01958eeb5d0ce213fcddc1eccbc38a696e81062"
+source = "git+https://github.com/RangerMauve/veilid-iroh-blobs.git?branch=default#f96a02a04e8dccccbf8d2db200f26bf714e3f2bc"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -6751,7 +6751,7 @@ dependencies = [
 [[package]]
 name = "veilid-tools"
 version = "0.3.4"
-source = "git+https://gitlab.com/veilid/veilid.git?branch=main#9bb4863b299e0998963bf860c47adbe445968a8a"
+source = "git+https://gitlab.com/veilid/veilid.git?branch=main#14cd561e09276fd17077c7c7e2b8ca287d42484b"
 dependencies = [
  "android_logger 0.13.3",
  "async-lock 3.4.0",

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -1,5 +1,6 @@
-use actix_web::{web, get, post, HttpResponse, Responder, Scope};
+use actix_web::{web, get, post, delete, HttpResponse, Responder, Scope};
 use serde::Deserialize;
+use serde_json::json;
 use crate::error::AppResult;
 use crate::models::SnowbirdRepo;
 use crate::server::server::{get_backend, GroupRepoPath};

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -33,7 +33,19 @@ async fn get_repo(path: web::Path<GroupRepoPath>) -> AppResult<impl Responder> {
     let repo = group.get_repo(&repo_crypto_key);
     
     // Convert the repo into the desired format and return the response
-    let snowbird_repo: SnowbirdRepo = repo?.clone().into();
+    
+    // First, handle the Result to get &Box<Repo>
+    let repo_box_ref = repo?;
+
+    // Then, dereference to get &Repo
+    let repo_ref = &**repo_box_ref;
+
+    // If Repo implements Clone, clone it to get an owned Repo
+    let repo_owned = repo_ref.clone();
+
+    // Now, convert the owned Repo into SnowbirdRepo
+    let snowbird_repo: SnowbirdRepo = repo_owned.into();
+
     Ok(HttpResponse::Ok().json(snowbird_repo))
 }
 
@@ -55,7 +67,17 @@ async fn create_repo(
 
     repo.set_name(&repo_data.name).await?;
 
-    let snowbird_repo: SnowbirdRepo = repo.clone().into(); 
+    // First, handle the Result to get &Box<Repo>
+    let repo_box_ref = repo;
+
+    // Then, dereference to get &Repo
+    let repo_ref = &**repo_box_ref;
+
+    // If Repo implements Clone, clone it to get an owned Repo
+    let repo_owned = repo_ref.clone();
+
+    // Now, convert the owned Repo into SnowbirdRepo
+    let snowbird_repo: SnowbirdRepo = repo_owned.into();
     
     Ok(HttpResponse::Ok().json(snowbird_repo))
 }

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -216,13 +216,15 @@ async fn download_file(
 
 
 
-#[delete("/{repo_id}/delete_file/{file_name}")]
+#[delete("/{repo_id}/media")]
 async fn delete_file(
-    path: web::Path<(GroupRepoPath, String)>,
+    path: web::Path<GroupRepoPath>,
+    query: web::Query<MediaQuery>,
 ) -> AppResult<impl Responder> {
-    let (path_params, file_name) = path.into_inner();
+    let path_params = path.into_inner();
     let group_id = &path_params.group_id;
     let repo_id = &path_params.repo_id;
+    let file_name = &query.file_name;
 
     // Fetch the backend and group
     let crypto_key = create_veilid_cryptokey_from_base64(&group_id)?;
@@ -234,7 +236,7 @@ async fn delete_file(
     let repo = group.get_repo(&repo_crypto_key)?;
 
     // Delete the file and update the collection
-    let collection_hash = repo.delete_file(&file_name).await?;
+    let collection_hash = repo.delete_file(file_name).await?;
     
     Ok(HttpResponse::Ok().json(collection_hash))
 }

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -89,7 +89,7 @@ struct UploadQuery {
     file_name: String,
 }
 
-#[post("/{repo_id}/upload")]
+#[post("/{repo_id}/media")]
 async fn upload_file(
     path: web::Path<GroupRepoPath>,
     query: web::Query<UploadQuery>,
@@ -183,7 +183,7 @@ async fn list_files(
     Ok(HttpResponse::Ok().json(files_with_status))
 }
 
-#[get("/{repo_id}/download/{file_name}")]
+#[get("/{repo_id}/media/{file_name}")]
 async fn download_file(
     path: web::Path<(GroupRepoPath, String)>,
 ) -> AppResult<impl Responder> {

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -1,12 +1,15 @@
-use actix_web::{web, get, post, delete, HttpResponse, Responder, Scope};
-use serde::Deserialize;
-use serde_json::json;
-use futures::StreamExt;
+use core::hash;
+
 use crate::error::AppResult;
 use crate::models::SnowbirdRepo;
 use crate::server::server::{get_backend, GroupRepoPath};
 use crate::utils::create_veilid_cryptokey_from_base64;
+use actix_web::{delete, get, post, web, HttpResponse, Responder, Scope};
+use futures::StreamExt;
 use save_dweb_backend::common::DHTEntity;
+use save_dweb_backend::group;
+use serde::Deserialize;
+use serde_json::json;
 
 pub fn scope() -> Scope {
     web::scope("/groups/{group_id}/repos")
@@ -16,7 +19,7 @@ pub fn scope() -> Scope {
 
 #[derive(Deserialize)]
 struct CreateRepoRequest {
-    name: String
+    name: String,
 }
 
 #[derive(Deserialize)]
@@ -38,9 +41,9 @@ async fn get_repo(path: web::Path<GroupRepoPath>) -> AppResult<impl Responder> {
     // Fetch the repo from the group
     let repo_crypto_key = create_veilid_cryptokey_from_base64(&repo_id)?;
     let repo = group.get_repo(&repo_crypto_key);
-    
+
     // Convert the repo into the desired format and return the response
-    
+
     // First, handle the Result to get &Box<Repo>
     let repo_box_ref = repo?;
 
@@ -59,14 +62,13 @@ async fn get_repo(path: web::Path<GroupRepoPath>) -> AppResult<impl Responder> {
 #[post("")]
 async fn create_repo(
     path: web::Path<String>,
-    body: web::Json<CreateRepoRequest>
+    body: web::Json<CreateRepoRequest>,
 ) -> AppResult<impl Responder> {
-
     let group_id = path.into_inner();
     let repo_data = body.into_inner();
 
     let backend = get_backend().await?;
-    
+
     let crypto_key = create_veilid_cryptokey_from_base64(&group_id)?;
     let mut group = backend.get_group(&crypto_key).await?;
 
@@ -85,31 +87,38 @@ async fn create_repo(
 
     // Now, convert the owned Repo into SnowbirdRepo
     let snowbird_repo: SnowbirdRepo = repo_owned.into();
-    
+
     Ok(HttpResponse::Ok().json(snowbird_repo))
 }
 
 #[post("/{repo_id}/media")]
 async fn upload_file(
     path: web::Path<GroupRepoPath>,
-    query: web::Query<MediaQuery>,  
+    query: web::Query<MediaQuery>,
     mut body: web::Payload,
 ) -> AppResult<impl Responder> {
     let path_params = path.into_inner();
     let group_id = &path_params.group_id;
     let repo_id = &path_params.repo_id;
-    let file_name = &query.file_name;  
+    let file_name = &query.file_name;
 
     // Fetch the backend and group with proper error handling
     let crypto_key = create_veilid_cryptokey_from_base64(&group_id)
         .map_err(|e| anyhow::anyhow!("Invalid group id: {}", e))?;
-    let backend = get_backend().await.map_err(|e| anyhow::anyhow!("Failed to get backend: {}", e))?;
-    let group = backend.get_group(&crypto_key).await.map_err(|e| anyhow::anyhow!("Failed to get group: {}", e))?;
+    let backend = get_backend()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to get backend: {}", e))?;
+    let group = backend
+        .get_group(&crypto_key)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to get group: {}", e))?;
 
     // Fetch the repo with proper error handling
     let repo_crypto_key = create_veilid_cryptokey_from_base64(&repo_id)
         .map_err(|e| anyhow::anyhow!("Invalid repo id: {}", e))?;
-    let repo = group.get_repo(&repo_crypto_key).map_err(|e| anyhow::anyhow!("Repo not found: {}", e))?;
+    let repo = group
+        .get_repo(&repo_crypto_key)
+        .map_err(|e| anyhow::anyhow!("Repo not found: {}", e))?;
 
     // Log file_name and stream file content
     log::info!("Uploading file: {}", file_name);
@@ -127,7 +136,9 @@ async fn upload_file(
     log::info!("Uploading file: {}", file_name);
 
     // Upload the file
-    let file_hash = repo.upload(file_name, file_data).await
+    let file_hash = repo
+        .upload(file_name, file_data)
+        .await
         .map_err(|e| anyhow::anyhow!("Failed to upload file: {}", e))?;
 
     log::info!("Updating DHT with hash: {}", file_hash);
@@ -135,7 +146,8 @@ async fn upload_file(
     // After uploading, update the DHT with the new file’s hash
     let updated_collection_hash = repo
         .set_file_and_update_dht(&repo.get_name().await?, file_name, &file_hash)
-        .await.map_err(|e| anyhow::anyhow!("Failed to update DHT: {}", e))?;
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to update DHT: {}", e))?;
 
     Ok(HttpResponse::Ok().json(json!({
         "file_hash": file_hash,
@@ -143,11 +155,8 @@ async fn upload_file(
     })))
 }
 
-
 #[get("/{repo_id}/list_files")]
-async fn list_files(
-    path: web::Path<GroupRepoPath>,
-) -> AppResult<impl Responder> {
+async fn list_files(path: web::Path<GroupRepoPath>) -> AppResult<impl Responder> {
     let path_params = path.into_inner();
     let group_id = &path_params.group_id;
     let repo_id = &path_params.repo_id;
@@ -160,6 +169,11 @@ async fn list_files(
     // Fetch the repo
     let repo_crypto_key = create_veilid_cryptokey_from_base64(&repo_id)?;
     let repo = group.get_repo(&repo_crypto_key)?;
+
+    let hash = repo.get_hash_from_dht().await?;
+    if !group.has_hash(&hash).await? {
+        group.download_hash_from_peers(&hash).await?;
+    }
 
     // List files and check if they are downloaded
     let files = repo.list_files().await?;
@@ -184,12 +198,12 @@ async fn list_files(
 #[get("/{repo_id}/media")]
 async fn download_file(
     path: web::Path<GroupRepoPath>,
-    query: web::Query<MediaQuery>,  
+    query: web::Query<MediaQuery>,
 ) -> AppResult<impl Responder> {
     let path_params = path.into_inner();
     let group_id = &path_params.group_id;
     let repo_id = &path_params.repo_id;
-    let file_name = &query.file_name; 
+    let file_name = &query.file_name;
 
     // Fetch the backend and group
     let crypto_key = create_veilid_cryptokey_from_base64(&group_id)?;
@@ -200,21 +214,29 @@ async fn download_file(
     let repo_crypto_key = create_veilid_cryptokey_from_base64(&repo_id)?;
     let repo = group.get_repo(&repo_crypto_key)?;
 
+    let collection_hash = repo.get_hash_from_dht().await?;
+    if !group.has_hash(&collection_hash).await? {
+        group.download_hash_from_peers(&collection_hash).await?;
+    }
+
     // Get the file hash
     let file_hash = repo.get_file_hash(file_name).await?;
 
+    if !group.has_hash(&hash).await? {
+        group.download_hash_from_peers(&hash).await?;
+    }
+
     // Trigger file download from peers using the hash
-    let file_data = group.download_hash_from_peers(&file_hash).await.map_err(|e| {
-        anyhow::anyhow!("Failed to download file from peers: {}", e)
-    })?;
+    let file_data = group
+        .download_hash_from_peers(&file_hash)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to download file from peers: {}", e))?;
 
     // Return the file data as a binary response
     Ok(HttpResponse::Ok()
         .content_type("application/octet-stream")
         .body(file_data))
 }
-
-
 
 #[delete("/{repo_id}/media")]
 async fn delete_file(
@@ -237,6 +259,6 @@ async fn delete_file(
 
     // Delete the file and update the collection
     let collection_hash = repo.delete_file(file_name).await?;
-    
+
     Ok(HttpResponse::Ok().json(collection_hash))
 }

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -19,6 +19,11 @@ struct CreateRepoRequest {
     name: String
 }
 
+#[derive(Deserialize)]
+struct MediaQuery {
+    file_name: String,
+}
+
 #[get("/{repo_id}")]
 async fn get_repo(path: web::Path<GroupRepoPath>) -> AppResult<impl Responder> {
     let path_params = path.into_inner();

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,7 @@
 #![allow(unused)]
 pub mod server {
     use actix_web::{web, App, Error as ActixError, HttpResponse, HttpServer, Responder};
-    use actix_web::{get, patch, post, put};
+    use actix_web::{get, patch, post, put, delete};
     use anyhow::{Context, Result, anyhow};
     use base64_url;
     use futures::{future, lock};


### PR DESCRIPTION
Adds the following operations:

 - post("/{repo_id}/media")
 - get("/{repo_id}/list_files")
 - get("/{repo_id}/media")
 - delete("/{repo_id}/media")
 
 #4 was merged for querystrings support

This closes https://github.com/hyphacoop/openarchive-dweb-backend/issues/49