### PR TITLE
Add GET endpoint to list all repos for a group

### DIFF
--- a/src/repos.rs
+++ b/src/repos.rs
@@ -12,6 +12,7 @@ pub fn scope() -> Scope {
     web::scope("/groups/{group_id}/repos")
         .service(create_repo)
         .service(get_repo)
+        .service(list_repos) 
 }
 
 #[derive(Deserialize)]

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -13,6 +13,10 @@ pub fn scope() -> Scope {
         .service(create_repo)
         .service(get_repo)
         .service(list_repos) 
+        .service(upload_file) 
+        .service(list_files) 
+        .service(download_file)
+        .service(delete_file)
 }
 
 #[derive(Deserialize)]

--- a/src/repos.rs
+++ b/src/repos.rs
@@ -56,6 +56,22 @@ async fn get_repo(path: web::Path<GroupRepoPath>) -> AppResult<impl Responder> {
     Ok(HttpResponse::Ok().json(snowbird_repo))
 }
 
+#[get("")]
+async fn list_repos(path: web::Path<String>) -> AppResult<impl Responder> {
+    let group_id = path.into_inner();
+
+    // Fetch the backend and the group
+    let crypto_key = create_veilid_cryptokey_from_base64(&group_id)?;
+    let backend = get_backend().await?;
+    let group = backend.get_group(&crypto_key).await?;
+
+    // Call the list_repos method to get the list of repo IDs
+    let repo_ids = group.list_repos();
+
+    // Return the list of repos as JSON
+    Ok(HttpResponse::Ok().json(repo_ids))
+}
+
 #[post("")]
 async fn create_repo(
     path: web::Path<String>,


### PR DESCRIPTION
- Adds a list_repos function in repos.rs that calls group.list_repos on the backend.
- Updates the Scope in repos.rs to include the new list_repos endpoint
- Adds other missing endpoints in the Scope:
   - .service(upload_file) 
   - .service(list_files) 
   - .service(download_file)
   - .service(delete_file)