### PR TITLE
File operations and media endpoint refactoring

### DIFF
--- a/src/groups.rs
+++ b/src/groups.rs
@@ -99,7 +99,7 @@ async fn join_group_from_url(request_url: web::Json<RequestUrl>) -> AppResult<im
     let backend_group = backend.join_from_url(&request.url).await?;
     log_debug!(TAG, "Joined backend group successfully");
 
-    let mut snowbird_group: SnowbirdGroup = (&backend_group).into();
+    let mut snowbird_group: SnowbirdGroup = (&*backend_group).into();
     log_debug!(TAG, "Converted to SnowbirdGroup");
 
     snowbird_group.fill_name(backend_group.as_ref()).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ mod tests {
         let file_content = b"Test content for file upload";
 
         let upload_req = test::TestRequest::post()
-            .uri(&format!("/api/groups/{}/repos/{}/media?file_name={}", group_id, repo_id, file_name))
+            .uri(&format!("/api/groups/{}/repos/{}/media/{}", group_id, repo_id, file_name))
             .set_payload(file_content.to_vec())
             .to_request();
         let upload_resp = test::call_service(&app, upload_req).await;
@@ -194,7 +194,7 @@ mod tests {
 
         // Step 5: Delete the file from the repository
         let delete_file_req = test::TestRequest::delete()
-            .uri(&format!("/api/groups/{}/repos/{}/media?file_name={}", group_id, repo_id, "example.txt"))
+            .uri(&format!("/api/groups/{}/repos/{}/media/{}", group_id, repo_id, "example.txt"))
             .to_request();
         let delete_resp = test::call_service(&app, delete_file_req).await;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use server::server::{get_backend, init_backend, status, BACKEND};
     use tmpdir::TmpDir;
+    use serde_json::json;
 
     #[derive(Serialize, Deserialize)]
     struct GroupsResponse {
@@ -111,4 +112,137 @@ mod tests {
 
         Ok(())
     }
+    
+    #[actix_web::test]
+    async fn test_api_file_operations() -> Result<()> {
+        // Initialize the app
+        let path = TmpDir::new("test_api_repo_file_operations").await?;
+
+        BACKEND.get_or_init(|| init_backend(path.to_path_buf().as_path()));
+
+        {
+            let backend = get_backend().await?;
+            backend.start().await.expect("Backend failed to start");
+        }
+
+        let app = test::init_service(
+            App::new()
+                .service(status)
+                .service(web::scope("/api").service(groups::scope())),
+        )
+        .await;
+
+        // Step 1: Create a group via the API
+        let create_group_req = test::TestRequest::post()
+            .uri("/api/groups")
+            .set_json(json!({ "name": "Test Group" }))
+            .to_request();
+        let create_group_resp: serde_json::Value = test::call_and_read_body_json(&app, create_group_req).await;
+        let group_id = create_group_resp["key"].as_str().expect("No group key returned");
+
+        // Step 2: Create a repo via the API
+        let create_repo_req = test::TestRequest::post()
+            .uri(&format!("/api/groups/{}/repos", group_id))
+            .set_json(json!({ "name": "Test Repo" }))
+            .to_request();
+        let create_repo_resp: serde_json::Value = test::call_and_read_body_json(&app, create_repo_req).await;
+
+        let repo_id = create_repo_resp["key"].as_str().expect("No repo key returned");
+
+        // Step 3: Upload a file to the repository
+        let file_name = "example.txt";
+        let file_content = b"Test content for file upload";
+
+        let upload_req = test::TestRequest::post()
+            .uri(&format!("/api/groups/{}/repos/{}/media?file_name={}", group_id, repo_id, file_name))
+            .set_payload(file_content.to_vec())
+            .to_request();
+        let upload_resp = test::call_service(&app, upload_req).await;
+
+        // Check upload success
+        assert!(upload_resp.status().is_success(), "File upload failed");
+
+        // Step 4: List files in the repository
+        let list_files_req = test::TestRequest::get()
+            .uri(&format!("/api/groups/{}/repos/{}/media", group_id, repo_id))
+            .to_request();
+        let list_files_resp: serde_json::Value = test::call_and_read_body_json(&app, list_files_req).await;
+
+        println!("List files response: {:?}", list_files_resp);
+
+        // Now check if the response is an array directly
+        if let Some(files_array) = list_files_resp.as_array() {
+            assert_eq!(
+                files_array.len(),
+                1,
+                "There should be one file in the repo"
+            );
+
+            // Ensure the file name matches what we uploaded
+            let file_obj = &files_array[0];
+            assert_eq!(
+                file_obj["name"].as_str().unwrap(),
+                "example.txt",
+                "The listed file should match the uploaded file"
+            );
+
+            let file_name = file_obj["name"].as_str().expect("File name not found");
+            assert_eq!(file_name, "example.txt", "File name does not match");
+
+            // Step 5: Now, test the file download response
+            let download_file_req = test::TestRequest::get()
+                .uri(&format!("/api/groups/{}/repos/{}/media?file_name={}", group_id, repo_id, "example.txt"))
+                .to_request();
+
+            let download_file_resp = test::call_service(&app, download_file_req).await;
+            let download_file_status = download_file_resp.status();
+            let download_file_body = test::read_body(download_file_resp).await;
+
+            println!("Download file response status: {:?}", download_file_status);
+            println!("Download file response body: {:?}", download_file_body);
+
+            // Verify the response status
+            assert_eq!(
+                download_file_status, 200,
+                "Expected successful file download, but got status: {:?}", download_file_status
+            );
+
+            // Compare the downloaded raw file content to the original content
+            assert_eq!(
+                &download_file_body[..],  // Ensure byte-by-byte comparison
+                b"Test content for file upload",
+                "Downloaded file content does not match uploaded content"
+            );
+
+            // Step 6: Delete the file from the repository
+            let delete_file_req = test::TestRequest::delete()
+                .uri(&format!("/api/groups/{}/repos/{}/media?file_name={}", group_id, repo_id, "example.txt"))
+                .to_request();
+            let delete_resp = test::call_service(&app, delete_file_req).await;
+
+            assert!(delete_resp.status().is_success(), "File deletion failed");
+
+            // Step 7: Verify the file is no longer listed
+            let list_files_after_deletion_req = test::TestRequest::get()
+                .uri(&format!("/api/groups/{}/repos/{}/media", group_id, repo_id))
+                .to_request();
+            let list_files_after_deletion_resp: serde_json::Value = test::call_and_read_body_json(&app, list_files_after_deletion_req).await;
+
+            assert!(
+                list_files_after_deletion_resp.as_array().unwrap().is_empty(),
+                "File list should be empty after file deletion"
+            );
+        } else {
+            panic!("The response is not an array as expected");
+        }
+
+        // Clean up: Stop the backend
+        {
+            let backend = get_backend().await?;
+            backend.stop().await.expect("Backend failed to stop");
+        }
+
+        Ok(())
+    }
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ mod tests {
     use server::server::{get_backend, init_backend, status, BACKEND};
     use tmpdir::TmpDir;
     use serde_json::json;
+    use std::sync::Arc;  
 
     #[derive(Serialize, Deserialize)]
     struct GroupsResponse {
@@ -112,6 +113,19 @@ mod tests {
 
         Ok(())
     }
+    use once_cell::sync::OnceCell;
+    use save_dweb_backend::backend::Backend;
+    use tokio::sync::Mutex as TokioMutex;
+    // Declare a second static `OnceCell` for the second backend
+    static BACKEND2: OnceCell<Arc<TokioMutex<Backend>>> = OnceCell::new();
+
+    pub async fn get_backend2<'a>(
+    ) -> Result<impl std::ops::DerefMut<Target = Backend> + 'a, anyhow::Error> {
+        match BACKEND2.get() {
+            Some(backend) => Ok(backend.lock().await),
+            None => Err(anyhow::anyhow!("Backend2 not initialized")),
+        }
+    }
     
     #[actix_web::test]
     async fn test_api_file_operations() -> Result<()> {
@@ -188,58 +202,79 @@ mod tests {
 
             let file_name = file_obj["name"].as_str().expect("File name not found");
             assert_eq!(file_name, "example.txt", "File name does not match");
-
-            // Step 5: Now, test the file download response
-            let download_file_req = test::TestRequest::get()
-                .uri(&format!("/api/groups/{}/repos/{}/media?file_name={}", group_id, repo_id, "example.txt"))
-                .to_request();
-
-            let download_file_resp = test::call_service(&app, download_file_req).await;
-            let download_file_status = download_file_resp.status();
-            let download_file_body = test::read_body(download_file_resp).await;
-
-            println!("Download file response status: {:?}", download_file_status);
-            println!("Download file response body: {:?}", download_file_body);
-
-            // Verify the response status
-            assert_eq!(
-                download_file_status, 200,
-                "Expected successful file download, but got status: {:?}", download_file_status
-            );
-
-            // Compare the downloaded raw file content to the original content
-            assert_eq!(
-                &download_file_body[..],  // Ensure byte-by-byte comparison
-                b"Test content for file upload",
-                "Downloaded file content does not match uploaded content"
-            );
-
-            // Step 6: Delete the file from the repository
-            let delete_file_req = test::TestRequest::delete()
-                .uri(&format!("/api/groups/{}/repos/{}/media?file_name={}", group_id, repo_id, "example.txt"))
-                .to_request();
-            let delete_resp = test::call_service(&app, delete_file_req).await;
-
-            assert!(delete_resp.status().is_success(), "File deletion failed");
-
-            // Step 7: Verify the file is no longer listed
-            let list_files_after_deletion_req = test::TestRequest::get()
-                .uri(&format!("/api/groups/{}/repos/{}/media", group_id, repo_id))
-                .to_request();
-            let list_files_after_deletion_resp: serde_json::Value = test::call_and_read_body_json(&app, list_files_after_deletion_req).await;
-
-            assert!(
-                list_files_after_deletion_resp.as_array().unwrap().is_empty(),
-                "File list should be empty after file deletion"
-            );
         } else {
             panic!("The response is not an array as expected");
         }
 
+        // Now we initialize the second backend to test file download
+        let backend2;
+        let path2 = TmpDir::new("test_api_repo_file_operations2").await?;
+
+        BACKEND2.get_or_init(|| init_backend(path2.to_path_buf().as_path()));
+
+        {
+            backend2 = get_backend2().await?;
+            backend2.start().await.expect("Backend2 failed to start");
+        }
+
+        let app2 = test::init_service(
+            App::new()
+                .service(status)
+                .service(web::scope("/api").service(groups::scope())),
+        )
+        .await;
+
+        // Step 5: we test the file download response
+        let download_file_req = test::TestRequest::get()
+            .uri(&format!("/api/groups/{}/repos/{}/media/download?file_name={}", group_id, repo_id, "example.txt"))
+            .to_request();
+
+        let download_file_resp = test::call_service(&app2, download_file_req).await;
+        let download_file_status = download_file_resp.status();
+        let download_file_body = test::read_body(download_file_resp).await;
+
+        println!("Download file response status: {:?}", download_file_status);
+        println!("Download file response body: {:?}", download_file_body);
+
+        // Verify the response status
+        assert_eq!(
+            download_file_status, 200,
+            "Expected successful file download, but got status: {:?}", download_file_status
+        );
+
+        // Compare the downloaded raw file content to the original content
+        assert_eq!(
+            &download_file_body[..],  // Ensure byte-by-byte comparison
+            b"Test content for file upload",
+            "Downloaded file content does not match uploaded content"
+        );
+
+        // Step 6: Delete the file from the repository
+        let delete_file_req = test::TestRequest::delete()
+            .uri(&format!("/api/groups/{}/repos/{}/media?file_name={}", group_id, repo_id, "example.txt"))
+            .to_request();
+        let delete_resp = test::call_service(&app, delete_file_req).await;
+
+        assert!(delete_resp.status().is_success(), "File deletion failed");
+
+        // Step 7: Verify the file is no longer listed
+        let list_files_after_deletion_req = test::TestRequest::get()
+            .uri(&format!("/api/groups/{}/repos/{}/media", group_id, repo_id))
+            .to_request();
+        let list_files_after_deletion_resp: serde_json::Value = test::call_and_read_body_json(&app, list_files_after_deletion_req).await;
+
+        assert!(
+            list_files_after_deletion_resp.as_array().unwrap().is_empty(),
+            "File list should be empty after file deletion"
+        );
+        
         // Clean up: Stop the backend
         {
             let backend = get_backend().await?;
             backend.stop().await.expect("Backend failed to stop");
+
+            let backend2 = get_backend2().await?; 
+            backend2.stop().await.expect("Backend2 failed to stop");
         }
 
         Ok(())

--- a/src/media.rs
+++ b/src/media.rs
@@ -2,13 +2,12 @@ use crate::constants::TAG;
 use crate::error::AppResult;
 use crate::log_info;
 use crate::logging::android_log;
-use crate::models::GroupRepoPath;
+use crate::models::{GroupRepoPath, GroupRepoMediaPath};
 use crate::server::server::get_backend;
 use crate::utils::create_veilid_cryptokey_from_base64;
 use actix_web::{delete, get, post, web, HttpResponse, Responder, Scope};
 use futures::StreamExt;
 use save_dweb_backend::common::DHTEntity;
-use serde::Deserialize;
 use serde_json::json;
 
 pub fn scope() -> Scope {
@@ -17,11 +16,6 @@ pub fn scope() -> Scope {
         .service(list_files)
         .service(delete_file)
         .service(download_file)
-}
-
-#[derive(Deserialize)]
-struct MediaQuery {
-    file_name: String,
 }
 
 #[get("")]

--- a/src/media.rs
+++ b/src/media.rs
@@ -67,7 +67,7 @@ async fn list_files(path: web::Path<GroupRepoPath>) -> AppResult<impl Responder>
     Ok(HttpResponse::Ok().json(files_with_status))
 }
 
-#[get("")]
+#[get("/download")]
 async fn download_file(
     path: web::Path<GroupRepoPath>,
     query: web::Query<MediaQuery>,

--- a/src/media.rs
+++ b/src/media.rs
@@ -15,11 +15,8 @@ pub fn scope() -> Scope {
     web::scope("/media")
         .service(upload_file)
         .service(list_files)
-        .service(
-            web::scope("/{media_id}")
-                .service(delete_file)
-                .service(download_file),
-        )
+        .service(delete_file)
+        .service(download_file)
 }
 
 #[derive(Deserialize)]

--- a/src/media.rs
+++ b/src/media.rs
@@ -58,15 +58,14 @@ async fn list_files(path: web::Path<GroupRepoPath>) -> AppResult<impl Responder>
     Ok(HttpResponse::Ok().json(files_with_status))
 }
 
-#[get("/download")]
+#[get("/{file_name}")]
 async fn download_file(
-    path: web::Path<GroupRepoPath>,
-    query: web::Query<MediaQuery>,
+    path: web::Path<GroupRepoMediaPath>
 ) -> AppResult<impl Responder> {
     let path_params = path.into_inner();
     let group_id = &path_params.group_id;
     let repo_id = &path_params.repo_id;
-    let file_name = &query.file_name;
+    let file_name = &path_params.file_name;
 
     // Fetch the backend and group
     let crypto_key = create_veilid_cryptokey_from_base64(&group_id)?;
@@ -83,7 +82,7 @@ async fn download_file(
     }
 
     // Get the file hash
-    let file_hash = repo.get_file_hash(file_name).await?;
+    let file_hash = repo.get_file_hash(&file_name).await?;
 
     if !group.has_hash(&file_hash).await? {
         group.download_hash_from_peers(&file_hash).await?;
@@ -101,15 +100,14 @@ async fn download_file(
         .body(file_data))
 }
 
-#[delete("")]
+#[delete("/{file_name}")]
 async fn delete_file(
-    path: web::Path<GroupRepoPath>,
-    query: web::Query<MediaQuery>,
+    path: web::Path<GroupRepoMediaPath>,
 ) -> AppResult<impl Responder> {
     let path_params = path.into_inner();
     let group_id = &path_params.group_id;
     let repo_id = &path_params.repo_id;
-    let file_name = &query.file_name;
+    let file_name = &path_params.file_name;
 
     // Fetch the backend and group
     let crypto_key = create_veilid_cryptokey_from_base64(&group_id)?;
@@ -121,21 +119,22 @@ async fn delete_file(
     let repo = group.get_repo(&repo_crypto_key).await?;
 
     // Delete the file and update the collection
-    let collection_hash = repo.delete_file(file_name).await?;
+    let collection_hash = repo.delete_file(&file_name).await?;
 
     Ok(HttpResponse::Ok().json(collection_hash))
 }
 
-#[post("")]
+#[post("/{file_name}")]
 async fn upload_file(
-    path: web::Path<GroupRepoPath>,
-    query: web::Query<MediaQuery>,
+    path: web::Path<GroupRepoMediaPath>,
     mut body: web::Payload,
 ) -> AppResult<impl Responder> {
     let path_params = path.into_inner();
     let group_id = &path_params.group_id;
     let repo_id = &path_params.repo_id;
-    let file_name = &query.file_name;
+    let file_name = &path_params.file_name;
+
+    println!("Uploading file: {}", file_name);
 
     // Fetch the backend and group with proper error handling
     let crypto_key = create_veilid_cryptokey_from_base64(&group_id)
@@ -175,7 +174,7 @@ async fn upload_file(
 
     // Upload the file
     let file_hash = repo
-        .upload(file_name, file_data)
+        .upload(&file_name, file_data)
         .await
         .map_err(|e| anyhow::anyhow!("Failed to upload file: {}", e))?;
 
@@ -183,7 +182,7 @@ async fn upload_file(
 
     // After uploading, update the DHT with the new file’s hash
     let updated_collection_hash = repo
-        .set_file_and_update_dht(&repo.get_name().await?, file_name, &file_hash)
+        .set_file_and_update_dht(&repo.get_name().await?, &file_name, &file_hash)
         .await
         .map_err(|e| anyhow::anyhow!("Failed to update DHT: {}", e))?;
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -16,6 +16,13 @@ pub struct GroupRepoPath {
     pub repo_id: String,
 }
 
+#[derive(Deserialize)]
+pub struct GroupRepoMediaPath {
+    pub group_id: String,
+    pub repo_id: String,
+    pub file_name: String, 
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RequestName {
     pub name: String,


### PR DESCRIPTION
- Removes {media_id} 
- Uses filename instead of media id
- Removes file name from query
- test_api_repo_file_operations tests upload, list and delete media file operations
- Closes hyphacoop/openarchive-dweb-backend#53