### PR TITLE
Fix: Add missing .await for Veilid API shutdown in Android bridge

### DIFF
--- a/src/android_bridge.rs
+++ b/src/android_bridge.rs
@@ -120,7 +120,7 @@ pub extern "system" fn Java_net_opendasharchive_openarchive_services_snowbird_Sn
                 // Get the backend to access Veilid API
                 if let Ok(mut backend) = crate::server::server::get_backend().await {
                     // Shutdown Veilid API
-                    if let Some(veilid_api) = backend.get_veilid_api() {
+                    if let Some(veilid_api) = backend.get_veilid_api().await {
                         veilid_api.shutdown().await;
                         log_info!(TAG, "Veilid API shut down successfully");
                     }


### PR DESCRIPTION
## Description
This PR fixes a type mismatch error in the Android bridge where `get_veilid_api()` was being called without `.await`. The function is async and returns a `Future<Option<VeilidAPI>>`, but was being used as if it returned an `Option<VeilidAPI>` directly.

## Changes
- Added `.await` to `backend.get_veilid_api()` call in `android_bridge.rs`
- This ensures proper async/await handling when shutting down the Veilid API


Fixes the following compilation error:
```

error[E0308]: mismatched types
--> src/android_bridge.rs:123:28
|
123 | if let Some(veilid_api) = backend.get_veilid_api() {
| ^^^^^^^^^^^^^^^^^^^^^^^^ expected future, found Option<_>
```