### PR TITLE
Pin iroh fork revisions and update backend tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3132,7 +3132,7 @@ dependencies = [
 [[package]]
 name = "iroh"
 version = "0.24.0"
-source = "git+https://github.com/tripledoublev/iroh.git?branch=relax-hickory#b3f52f6d8bba462eebd7e3991946d844c9a75039"
+source = "git+https://github.com/tripledoublev/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3176,7 +3176,7 @@ dependencies = [
 [[package]]
 name = "iroh-base"
 version = "0.24.0"
-source = "git+https://github.com/tripledoublev/iroh.git?branch=relax-hickory#b3f52f6d8bba462eebd7e3991946d844c9a75039"
+source = "git+https://github.com/tripledoublev/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
 dependencies = [
  "aead",
  "anyhow",
@@ -3217,7 +3217,7 @@ dependencies = [
 [[package]]
 name = "iroh-blobs"
 version = "0.24.0"
-source = "git+https://github.com/tripledoublev/iroh.git?branch=relax-hickory#b3f52f6d8bba462eebd7e3991946d844c9a75039"
+source = "git+https://github.com/tripledoublev/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3259,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "iroh-docs"
 version = "0.24.0"
-source = "git+https://github.com/tripledoublev/iroh.git?branch=relax-hickory#b3f52f6d8bba462eebd7e3991946d844c9a75039"
+source = "git+https://github.com/tripledoublev/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3297,7 +3297,7 @@ dependencies = [
 [[package]]
 name = "iroh-gossip"
 version = "0.24.0"
-source = "git+https://github.com/tripledoublev/iroh.git?branch=relax-hickory#b3f52f6d8bba462eebd7e3991946d844c9a75039"
+source = "git+https://github.com/tripledoublev/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3337,7 +3337,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.24.0"
-source = "git+https://github.com/tripledoublev/iroh.git?branch=relax-hickory#b3f52f6d8bba462eebd7e3991946d844c9a75039"
+source = "git+https://github.com/tripledoublev/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
 dependencies = [
  "anyhow",
  "erased_set",
@@ -3357,7 +3357,7 @@ dependencies = [
 [[package]]
 name = "iroh-net"
 version = "0.24.0"
-source = "git+https://github.com/tripledoublev/iroh.git?branch=relax-hickory#b3f52f6d8bba462eebd7e3991946d844c9a75039"
+source = "git+https://github.com/tripledoublev/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
 dependencies = [
  "anyhow",
  "backoff",
@@ -5750,7 +5750,7 @@ dependencies = [
 
 [[package]]
 name = "save"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -5781,8 +5781,8 @@ dependencies = [
 
 [[package]]
 name = "save-dweb-backend"
-version = "0.3.3"
-source = "git+https://github.com/OpenArchive/save-dweb-backend?tag=v0.3.3#1eb5f492eee2c50b5e9782f69c58205a89a04233"
+version = "0.3.4"
+source = "git+https://github.com/OpenArchive/save-dweb-backend?tag=v0.3.4#e997584efa0a6a2ad5af116045508e8b7eef75c6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7474,8 +7474,8 @@ dependencies = [
 
 [[package]]
 name = "veilid-iroh-blobs"
-version = "0.3.1"
-source = "git+https://github.com/RangerMauve/veilid-iroh-blobs?tag=v0.3.1#e17c546c278266c1108d1ca756c9e31e03432b18"
+version = "0.3.2"
+source = "git+https://github.com/RangerMauve/veilid-iroh-blobs?tag=v0.3.2#9c58b16fde7c2a881dc057e0556b1ae66a51a2c2"
 dependencies = [
  "anyhow",
  "bytes 1.11.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ ios = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-save-dweb-backend = { git = "https://github.com/OpenArchive/save-dweb-backend", tag = "v0.3.3" }
+save-dweb-backend = { git = "https://github.com/OpenArchive/save-dweb-backend", tag = "v0.3.4" }
 tokio = { version = "^1.43",  default-features = false, features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -63,10 +63,10 @@ serial_test = "2.0"
 # Patch iroh crates to relax hickory-resolver pin for veilid-core 0.5.2 compat.
 # All iroh workspace crates must come from the same source to avoid duplicate type errors.
 [patch.crates-io]
-iroh = { git = "https://github.com/tripledoublev/iroh.git", branch = "relax-hickory" }
-iroh-net = { git = "https://github.com/tripledoublev/iroh.git", branch = "relax-hickory" }
-iroh-base = { git = "https://github.com/tripledoublev/iroh.git", branch = "relax-hickory" }
-iroh-metrics = { git = "https://github.com/tripledoublev/iroh.git", branch = "relax-hickory" }
-iroh-blobs = { git = "https://github.com/tripledoublev/iroh.git", branch = "relax-hickory" }
-iroh-docs = { git = "https://github.com/tripledoublev/iroh.git", branch = "relax-hickory" }
-iroh-gossip = { git = "https://github.com/tripledoublev/iroh.git", branch = "relax-hickory" }
+iroh = { git = "https://github.com/tripledoublev/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }
+iroh-net = { git = "https://github.com/tripledoublev/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }
+iroh-base = { git = "https://github.com/tripledoublev/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }
+iroh-metrics = { git = "https://github.com/tripledoublev/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }
+iroh-blobs = { git = "https://github.com/tripledoublev/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }
+iroh-docs = { git = "https://github.com/tripledoublev/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }
+iroh-gossip = { git = "https://github.com/tripledoublev/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }


### PR DESCRIPTION
## Summary
- pin patched iroh crates to the verified immutable fork commit instead of the floating relax-hickory branch
- update save-dweb-backend to v0.3.4
- pull in veilid-iroh-blobs v0.3.2 through the backend dependency update

## Testing
- cargo check
