### PR TITLE
Bump backend to v0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-05-31
+
+- Bump `save-dweb-backend` dependency to `v0.3.7`.
+- Bump `save` crate version to `0.2.4`.
+
 ## 2026-02-17
 
 - Upgrade to `veilid-core` v0.5.2.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5766,7 +5766,7 @@ dependencies = [
 
 [[package]]
 name = "save"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -5798,8 +5798,8 @@ dependencies = [
 
 [[package]]
 name = "save-dweb-backend"
-version = "0.3.6"
-source = "git+https://github.com/OpenArchive/save-dweb-backend?tag=v0.3.6#1c0c3faf3a0620a52e91731e6cfd56f3fc6f7fe5"
+version = "0.3.7"
+source = "git+https://github.com/OpenArchive/save-dweb-backend?tag=v0.3.7#5c043085b09f1b0fd6da2c5f1b4e9195918353e3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "save"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Richard Puckett <richard@open-archive.org"]
 description = "Decentralized Web for Save"
 edition = "2021"
@@ -28,7 +28,7 @@ ios = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-save-dweb-backend = { git = "https://github.com/OpenArchive/save-dweb-backend", tag = "v0.3.6" }
+save-dweb-backend = { git = "https://github.com/OpenArchive/save-dweb-backend", tag = "v0.3.7" }
 tokio = { version = "^1.43",  default-features = false, features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Summary
- bump save-dweb-backend to v0.3.7
- bump save crate version to 0.2.4
- update CHANGELOG.md for the release

## Verification
- cargo fmt --check
- cargo clippy --all-targets --all-features -- -D warnings
- SAVE_VEILID_LOCAL_TEST_MODE=1 cargo nextest run --profile ci-virtual --no-fail-fast -E 'test(basic_test) | test(test_health_endpoint) | test(test_upload_list_delete)'