### PR TITLE
chore: release v0.2.8 (veilid 0.5.5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,12 +585,10 @@ dependencies = [
  "blanket",
  "futures-core",
  "futures-task",
- "futures-timer",
  "futures-util",
  "pin-project",
  "rustc_version",
  "tokio",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -2277,10 +2275,6 @@ name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-dependencies = [
- "gloo-timers",
- "send_wrapper 0.4.0",
-]
 
 [[package]]
 name = "futures-util"
@@ -2457,18 +2451,6 @@ checksum = "8c6a94fa8cd88bea0babf8a27fe9abbcdece831fd1c3c84dd5c231fab4685ec7"
 dependencies = [
  "wasm-bindgen",
  "web-sys",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2929,7 +2911,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3748,7 +3730,7 @@ dependencies = [
  "keyvaluedb",
  "keyvaluedb-memorydb",
  "log",
- "send_wrapper 0.6.0",
+ "send_wrapper",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -5859,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "save"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -5891,8 +5873,8 @@ dependencies = [
 
 [[package]]
 name = "save-dweb-backend"
-version = "0.3.10"
-source = "git+https://github.com/OpenArchive/save-dweb-backend?tag=v0.3.10#33bfd16117c00b9f478a015e7a35c51e0713cc60"
+version = "0.3.11"
+source = "git+https://github.com/OpenArchive/save-dweb-backend?tag=v0.3.11#c3bd1f0766e948e4044cec25283c5e3588b3f5ae"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -6067,12 +6049,6 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
-
-[[package]]
-name = "send_wrapper"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
 
 [[package]]
 name = "send_wrapper"
@@ -6843,7 +6819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -7460,8 +7436,8 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "veilid-core"
-version = "0.5.4"
-source = "git+https://gitlab.com/veilid/veilid.git?tag=v0.5.4#622909d34a7f322e835b2c647f1da7db01210264"
+version = "0.5.5"
+source = "git+https://gitlab.com/veilid/veilid.git?tag=v0.5.5#bbb212de91b492fb9a55b6d5b9084965c05c17cf"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -7507,7 +7483,7 @@ dependencies = [
  "range-set-blaze 0.5.0",
  "sanitize-filename",
  "schemars 1.2.1",
- "send_wrapper 0.6.0",
+ "send_wrapper",
  "serde",
  "serde-wasm-bindgen",
  "serde_bytes",
@@ -7557,8 +7533,8 @@ dependencies = [
 
 [[package]]
 name = "veilid-iroh-blobs"
-version = "0.3.6"
-source = "git+https://github.com/RangerMauve/veilid-iroh-blobs?tag=v0.3.6#4bebe6b1f24774c8fb62cf3588e4873ab75e7705"
+version = "0.3.7"
+source = "git+https://github.com/RangerMauve/veilid-iroh-blobs?tag=v0.3.7#6e3ae5b31c7d5f47762b2404ba5a5ef4ec3730c9"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7578,8 +7554,8 @@ dependencies = [
 
 [[package]]
 name = "veilid-tools"
-version = "0.5.4"
-source = "git+https://gitlab.com/veilid/veilid.git?tag=v0.5.4#622909d34a7f322e835b2c647f1da7db01210264"
+version = "0.5.5"
+source = "git+https://gitlab.com/veilid/veilid.git?tag=v0.5.5#bbb212de91b492fb9a55b6d5b9084965c05c17cf"
 dependencies = [
  "android_logger",
  "async-io",
@@ -7613,7 +7589,7 @@ dependencies = [
  "range-set-blaze 0.4.4",
  "rayon",
  "rtnetlink 0.20.0",
- "send_wrapper 0.6.0",
+ "send_wrapper",
  "serde",
  "shell-words",
  "socket2 0.6.2",
@@ -7627,7 +7603,6 @@ dependencies = [
  "veilid-hashlink",
  "winapi",
  "windows 0.62.2",
- "ws_stream_wasm",
 ]
 
 [[package]]
@@ -8329,7 +8304,7 @@ dependencies = [
  "log",
  "pharos",
  "rustc_version",
- "send_wrapper 0.6.0",
+ "send_wrapper",
  "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "save"
-version = "0.2.7"
+version = "0.2.8"
 description = "Decentralized Web for Save"
 edition = "2021"
 publish = false
@@ -27,8 +27,8 @@ ios = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# Matches Veilid 0.5.4.
-save-dweb-backend = { git = "https://github.com/OpenArchive/save-dweb-backend", tag = "v0.3.10" }
+# Matches Veilid 0.5.5.
+save-dweb-backend = { git = "https://github.com/OpenArchive/save-dweb-backend", tag = "v0.3.11" }
 tokio = { version = "^1.43",  default-features = false, features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -37,7 +37,7 @@ lazy_static = "1.4"
 actix-web = { version = "4", features = ["macros"] }
 futures = "0.3"
 eyre = "0.6.12"
-veilid-core = { git = "https://gitlab.com/veilid/veilid.git", tag = "v0.5.4" }
+veilid-core = { git = "https://gitlab.com/veilid/veilid.git", tag = "v0.5.5" }
 once_cell = "1.20.1"
 base64-url = "3.0.0"
 thiserror = "1.0.64"
@@ -55,13 +55,13 @@ env_logger = "0.10"
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.22.4"
 tokio = { version = "^1.43",  default-features = false,  features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }
-veilid-core = { git = "https://gitlab.com/veilid/veilid.git", tag = "v0.5.4" }
+veilid-core = { git = "https://gitlab.com/veilid/veilid.git", tag = "v0.5.5" }
 blake3 = "1.8.2"
 
 [dev-dependencies]
 serial_test = "2.0"
 
-# Patch iroh crates to relax hickory-resolver pin for veilid-core 0.5.4 compat.
+# Patch iroh crates to relax hickory-resolver pin for veilid-core 0.5.5 compat.
 # All iroh workspace crates must come from the same source to avoid duplicate type errors.
 [patch.crates-io]
 iroh = { git = "https://github.com/tripledoublev/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }


### PR DESCRIPTION
## Summary
- `veilid-core` git tag `v0.5.4` → `v0.5.5` in **both** stanzas (default deps + `cfg(target_os = "android")` target).
- `save-dweb-backend` git tag `v0.3.10` → `v0.3.11` (built against veilid 0.5.5; OpenArchive/save-dweb-backend#40).
- Package version `0.2.7` → `0.2.8`.
- **Compatibility patch retained**: `hickory-resolver = "=0.25.2"` and the 7 `tripledoublev/iroh` `[patch.crates-io]` entries are unchanged — `veilid-tools` v0.5.5 still pins `hickory-resolver 0.25.2`.

## Test plan
- `cargo build` ✅
- Smoke set `cargo nextest run -E 'test(basic_test) | test(test_health_endpoint) | test(test_upload_list_delete)'` ✅ — 3 passed.
- `test_refresh_empty_group` passes on 0.5.5 ✅. It surfaced as flaky during the full run (`TryAgain: offline` — Veilid network-attach timing); **verified pre-existing**: the same test is flaky on the 0.5.4 baseline (failed 3 tries, passed on the 4th). Not a 0.5.5 regression.

## Follow-up (separate)
`test_refresh_empty_group` lacks the retry override its sibling refresh tests have in `.config/nextest.toml`; adding it there would stabilize CI. Out of scope for this dependency bump.

Final step of the Veilid 0.5.5 cross-repo cascade (veilid-iroh-blobs v0.3.7 ✅ → save-dweb-backend v0.3.11 ✅ → **save-rust v0.2.8**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)