### PR TITLE
chore: use OpenArchive iroh fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5873,8 +5873,8 @@ dependencies = [
 
 [[package]]
 name = "save-dweb-backend"
-version = "0.3.11"
-source = "git+https://github.com/OpenArchive/save-dweb-backend?tag=v0.3.11#c3bd1f0766e948e4044cec25283c5e3588b3f5ae"
+version = "0.3.12"
+source = "git+https://github.com/OpenArchive/save-dweb-backend?tag=v0.3.12#245fea1888de3c81b9cce3952a0d1a31ab6ebd1a"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -7534,7 +7534,7 @@ dependencies = [
 [[package]]
 name = "veilid-iroh-blobs"
 version = "0.3.7"
-source = "git+https://github.com/RangerMauve/veilid-iroh-blobs?tag=v0.3.7#6e3ae5b31c7d5f47762b2404ba5a5ef4ec3730c9"
+source = "git+https://github.com/OpenArchive/veilid-iroh-blobs?tag=v0.3.8#f42bb8254052ae530f387c532209bdcb947f62ce"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3200,7 +3200,7 @@ dependencies = [
 [[package]]
 name = "iroh"
 version = "0.24.0"
-source = "git+https://github.com/tripledoublev/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
+source = "git+https://github.com/OpenArchive/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3244,7 +3244,7 @@ dependencies = [
 [[package]]
 name = "iroh-base"
 version = "0.24.0"
-source = "git+https://github.com/tripledoublev/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
+source = "git+https://github.com/OpenArchive/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
 dependencies = [
  "aead 0.5.2",
  "anyhow",
@@ -3285,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "iroh-blobs"
 version = "0.24.0"
-source = "git+https://github.com/tripledoublev/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
+source = "git+https://github.com/OpenArchive/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3327,7 +3327,7 @@ dependencies = [
 [[package]]
 name = "iroh-docs"
 version = "0.24.0"
-source = "git+https://github.com/tripledoublev/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
+source = "git+https://github.com/OpenArchive/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3365,7 +3365,7 @@ dependencies = [
 [[package]]
 name = "iroh-gossip"
 version = "0.24.0"
-source = "git+https://github.com/tripledoublev/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
+source = "git+https://github.com/OpenArchive/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",
@@ -3405,7 +3405,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.24.0"
-source = "git+https://github.com/tripledoublev/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
+source = "git+https://github.com/OpenArchive/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
 dependencies = [
  "anyhow",
  "erased_set",
@@ -3425,7 +3425,7 @@ dependencies = [
 [[package]]
 name = "iroh-net"
 version = "0.24.0"
-source = "git+https://github.com/tripledoublev/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
+source = "git+https://github.com/OpenArchive/iroh.git?rev=b3f52f6d8bba462eebd7e3991946d844c9a75039#b3f52f6d8bba462eebd7e3991946d844c9a75039"
 dependencies = [
  "anyhow",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ ios = []
 
 [dependencies]
 # Matches Veilid 0.5.5.
-save-dweb-backend = { git = "https://github.com/OpenArchive/save-dweb-backend", tag = "v0.3.11" }
+save-dweb-backend = { git = "https://github.com/OpenArchive/save-dweb-backend", tag = "v0.3.12" }
 tokio = { version = "^1.43",  default-features = false, features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,10 +64,10 @@ serial_test = "2.0"
 # Patch iroh crates to relax hickory-resolver pin for veilid-core 0.5.5 compat.
 # All iroh workspace crates must come from the same source to avoid duplicate type errors.
 [patch.crates-io]
-iroh = { git = "https://github.com/tripledoublev/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }
-iroh-net = { git = "https://github.com/tripledoublev/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }
-iroh-base = { git = "https://github.com/tripledoublev/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }
-iroh-metrics = { git = "https://github.com/tripledoublev/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }
-iroh-blobs = { git = "https://github.com/tripledoublev/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }
-iroh-docs = { git = "https://github.com/tripledoublev/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }
-iroh-gossip = { git = "https://github.com/tripledoublev/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }
+iroh = { git = "https://github.com/OpenArchive/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }
+iroh-net = { git = "https://github.com/OpenArchive/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }
+iroh-base = { git = "https://github.com/OpenArchive/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }
+iroh-metrics = { git = "https://github.com/OpenArchive/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }
+iroh-blobs = { git = "https://github.com/OpenArchive/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }
+iroh-docs = { git = "https://github.com/OpenArchive/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }
+iroh-gossip = { git = "https://github.com/OpenArchive/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }


### PR DESCRIPTION
## Summary
- repoint save-rust's direct iroh patch crates from tripledoublev/iroh to OpenArchive/iroh
- keep pinned revisions unchanged

## Verification
- cargo update -p iroh -p iroh-net -p iroh-base -p iroh-metrics -p iroh-blobs -p iroh-docs -p iroh-gossip
- cargo build

## Note
Cargo.lock still contains a transitive RangerMauve/veilid-iroh-blobs source through save-dweb-backend v0.3.11. That will clear after OpenArchive/save-dweb-backend#41 merges, a new save-dweb-backend release tag is cut, and save-rust updates to that tag.